### PR TITLE
automerge-flathubbot-prs is no longer allowed

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
https://docs.flathub.org/blog/linter-restricting-automatic-merge/